### PR TITLE
Dots now only spawn when other dots are eaten

### DIFF
--- a/Assets/Scripts/createDots.cs
+++ b/Assets/Scripts/createDots.cs
@@ -20,18 +20,11 @@ public class createDots : MonoBehaviour {
 	
 	// Update is called once per frame
 	void FixedUpdate () {
-		//removes time that has past from timer (time since last frame)
-		timer += Time.deltaTime;
-		if (timer >= secondsBetweenRounds) {
-			//goes back to 0
-			timer = 0;
-			//gets all current dots
-			GameObject[] dotsArray = GameObject.FindGameObjectsWithTag("dot");
-			//sees if we need to add some
-			if(dotsArray.Length < amountOfDotsPerRound){
-				//adds them 
-				addDots(amountOfDotsPerRound - dotsArray.Length);
-			}
+		if (GameObject.FindGameObjectsWithTag ("dot").Length < amountOfDotsPerRound) {
+			//get the amount that have died
+			int amountLeftOver = amountOfDotsPerRound - GameObject.FindGameObjectsWithTag ("dot").Length;
+			//go through them all
+			addDots (amountLeftOver);
 		}
 	}
 	void addDots(int amountToAdd){


### PR DESCRIPTION
When a dot is eaten, another one spawns at a random location, instead
of a certain amount of dots spawning every few seconds.
